### PR TITLE
fixed settings with root account

### DIFF
--- a/project/environments/01-dev/init-pipeline-runner-vm/infra/image/packer/proxmox/ubuntu-server-jammy/credentials.pkr.hcl
+++ b/project/environments/01-dev/init-pipeline-runner-vm/infra/image/packer/proxmox/ubuntu-server-jammy/credentials.pkr.hcl
@@ -1,3 +1,3 @@
-proxmox_api_url = "" # This is the Proxmox server's static IP
-proxmox_api_token_id = "" # This is the API Token ID 
-proxmox_api_token_secret = "" # This is the API Token proxmox_api_token_secret
+proxmox_api_url = "https://{{ .HTTPIP }}:8006/api2/json" # This is the Proxmox server's static IP
+proxmox_api_token_id = "INSERT_TOKEN_ID_HERE" # This is the API Token ID 
+proxmox_api_token_secret = "INSERT_TOKEN_HERE" # This is the API Token proxmox_api_token_secret

--- a/project/environments/01-dev/init-pipeline-runner-vm/infra/image/packer/proxmox/ubuntu-server-jammy/http/user-data
+++ b/project/environments/01-dev/init-pipeline-runner-vm/infra/image/packer/proxmox/ubuntu-server-jammy/http/user-data
@@ -7,7 +7,7 @@ autoinstall:
     layout: de
   ssh:
     install-server: true
-    allow-pw: false
+    allow-pw: true
     disable_root: true
     ssh_quiet_keygen: true
     allow_public_ssh_keys: true
@@ -23,12 +23,12 @@ autoinstall:
     package_upgrade: false
     timezone: America/New York
     users:
-      - name: packer
+      - name: root
         shell: /bin/bash
         sudo: ALL=(ALL) NOPASSWD:ALL
         lock-passwd: false
         groups: [adm, sudo]
-        ssh_authorized_keys:
+        ssh_authorized_keys: 
           - your-ssh-key
         #  OR
         # passwd: your-password

--- a/project/environments/01-dev/init-pipeline-runner-vm/infra/image/packer/proxmox/ubuntu-server-jammy/ubuntu-server-jammy.pkr.hcl
+++ b/project/environments/01-dev/init-pipeline-runner-vm/infra/image/packer/proxmox/ubuntu-server-jammy/ubuntu-server-jammy.pkr.hcl
@@ -37,7 +37,7 @@ source "proxmox" "ubuntu-server-jammy" {
     proxmox_url = "${var.proxmox_api_url}"
     
     # TLS Verification Skip (If needed)
-    # insecure_skip_tls_verify = true
+    insecure_skip_tls_verify = true
     
     # VM General Settings
     node = "tva" # Name of the destination "node" on Proxmox
@@ -90,18 +90,19 @@ source "proxmox" "ubuntu-server-jammy" {
     
     # Packer Boot Commands
     boot_command = [
-        "<esc><wait><esc><wait>",
-        "<f6><wait><esc><wait>",
-        "<bs><bs><bs><bs><bs>",
-        "autoinstall ds=nocloud-net;s=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ ",
-        "--- <enter>"
+        "<esc><wait>",
+        "e<wait>",
+        "<down><down><down><end>",
+        "<bs><bs><bs><bs><wait>",
+        "autoinstall ds=nocloud-net\\;s=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ ---<wait>",
+        "<f10><wait>"
     ]
     boot = "c"
     boot_wait = "5s"
 
     # Packer HTTP Server Settings for Autoinstall
     http_directory = "http" 
-    ssh_username = "packer"
+    ssh_username = "root"
     
 
     # Bind IP Address and Port Statically

--- a/project/environments/01-dev/init-proxmox-config/ansible/init-create-service-accounts/create_admin_login.sh
+++ b/project/environments/01-dev/init-proxmox-config/ansible/init-create-service-accounts/create_admin_login.sh
@@ -2,12 +2,12 @@
 
 # Make user account
 echo "Make user account..."
-useradd --shell /bin/bash --create-home --home-dir /home/lifeless/ lifeless
+useradd --shell /bin/bash --create-home --home-dir /home/admin admin
 
 # Give sudo access
 echo "Give sudo access"
-usermod -aG sudo lifeless
+usermod -aG sudo admin
 
 # Set password
 echo "Set password..."
-passwd lifeless
+passwd admin


### PR DESCRIPTION
fixed several things:

- changed the accounts and tokens based on `root`
- pointed the API URL to the correct address
- skipping TLS verification
- changed boot commands